### PR TITLE
Add social handle to header

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -37,6 +37,7 @@ export default function Header() {
             <p className="text-sm text-gray-500 -mt-0.5 italic">
               Learn to Rank #1 in Google
             </p>
+            <p className="text-xs text-gray-500">@niblahistaken</p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- show the `@niblahistaken` handle under the tagline next to the avatar in the header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688273fcce64832db6f9f5eb01531a9e