### PR TITLE
Add remote verified badge

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'schilderenopnummerwinkel.nl',
+        pathname: '/wp-content/uploads/**',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -37,6 +37,15 @@ export default function Header() {
             <p className="text-sm text-gray-500 -mt-0.5 italic">
               Learn to Rank #1 in Google
             </p>
+            <div className="flex items-center space-x-1 text-xs text-gray-500">
+              <span>@niblahistaken</span>
+              <Image
+                src="https://schilderenopnummerwinkel.nl/wp-content/uploads/2025/07/Twitter_Verified_Badge.svg.png"
+                alt="Twitter Verified Badge"
+                width={16}
+                height={16}
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow remote images from `schilderenopnummerwinkel.nl`
- show the verified badge in the header using the remote URL
- remove the unused local copy of the badge

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688273fcce64832db6f9f5eb01531a9e